### PR TITLE
Cleanup files

### DIFF
--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -212,11 +212,20 @@ function cleanupFile
     }
 }
 
-function GetUnattendChunk ([string]$pass, [string]$component, [xml]$unattend) 
-    {# Helper function that returns one component chunk from the Unattend XML data structure
-     return $Unattend.unattend.settings | ? pass -eq $pass `
-                                        | select -ExpandProperty component `
-                                        | ? name -eq $component}
+function GetUnattendChunk 
+{
+    param
+    (
+        [string] $pass, 
+        [string] $component, 
+        [xml] $unattend
+    ); 
+    
+    # Helper function that returns one component chunk from the Unattend XML data structure
+    return $Unattend.unattend.settings | ? pass -eq $pass `
+        | select -ExpandProperty component `
+        | ? name -eq $component;
+}
 
 function makeUnattendFile ([string]$key, [string]$logonCount, [string]$filePath, [bool]$desktop = $false, [bool]$is32bit = $false) 
     {# Composes unattend file and writes it to the specified filepath

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -368,11 +368,12 @@ $updateCheckScriptBlock = {
 
 ### Sysprep script block
 $sysprepScriptBlock = {
-     # Remove autorun key if it exists
-     Get-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run | ? Property -like Unattend* | Remove-Item
+    # Remove autorun key if it exists
+    Get-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run | ? Property -like Unattend* | Remove-Item;
              
-     $unattendedXmlPath = "$ENV:SystemDrive\Bits\Unattend.xml" 
-     & "$ENV:SystemRoot\System32\Sysprep\Sysprep.exe" `/generalize `/oobe `/shutdown `/unattend:"$unattendedXmlPath"}
+    $unattendedXmlPath = "$ENV:SystemDrive\Bits\Unattend.xml";
+    & "$ENV:SystemRoot\System32\Sysprep\Sysprep.exe" `/generalize `/oobe `/shutdown `/unattend:"$unattendedXmlPath";
+};
 
 ### Post Sysprep script block
 $postSysprepScriptBlock = {

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -326,29 +326,45 @@ function MountVHDandRunBlock
 
 ### Update script block
 $updateCheckScriptBlock = {
-     # Clean up unattend file if it is there
-     if (test-path "$ENV:SystemDrive\Unattend.xml") {Remove-Item -Force "$ENV:SystemDrive\Unattend.xml"}
+    # Clean up unattend file if it is there
+    if (Test-Path "$ENV:SystemDrive\Unattend.xml") 
+    {
+        Remove-Item -Force "$ENV:SystemDrive\Unattend.xml"
+    }
      
-     # Check to see if files need to be unblocked - if they do, do it and reboot
-     if ((Get-ChildItem $env:SystemDrive\Bits\PSWindowsUpdate | `
-          get-item -Stream "Zone.Identifier" -ErrorAction SilentlyContinue).Count -gt 0)
-        {Get-ChildItem $env:SystemDrive\Bits\PSWindowsUpdate  | Unblock-File
-         invoke-expression 'shutdown -r -t 0'}
+    # Check to see if files need to be unblocked - if they do, do it and reboot
+    if ((Get-ChildItem $env:SystemDrive\Bits\PSWindowsUpdate | `
+        Get-Item -Stream "Zone.Identifier" -ErrorAction SilentlyContinue).Count -gt 0)
+    {
+        Get-ChildItem $env:SystemDrive\Bits\PSWindowsUpdate | Unblock-File;
+        Invoke-Expression 'shutdown -r -t 0'
+    }
 
-     # To get here - the files are unblocked
-     import-module $env:SystemDrive\Bits\PSWindowsUpdate\PSWindowsUpdate
+    # To get here - the files are unblocked
+    Import-Module $env:SystemDrive\Bits\PSWindowsUpdate\PSWindowsUpdate;
 
-     # Check if any updates are needed - leave a marker if there are
-     if ((Get-WUList).Count -gt 0)
-          {if (!(test-path $env:SystemDrive\Bits\changesMade.txt)) 
-          {New-Item $env:SystemDrive\Bits\changesMade.txt -type file}}
+    # Check if any updates are needed - leave a marker if there are
+    if ((Get-WUList).Count -gt 0)
+    {
+        if (-not (Test-Path $env:SystemDrive\Bits\changesMade.txt))
+        {
+            New-Item $env:SystemDrive\Bits\changesMade.txt -type file;
+        }
+    }
  
-     # Apply all the updates
-     Get-WUInstall -AcceptAll -IgnoreReboot -IgnoreUserInput -NotCategory "Language packs" 
+    # Apply all the updates
+    Get-WUInstall -AcceptAll -IgnoreReboot -IgnoreUserInput -NotCategory "Language packs";
 
-     # Reboot if needed - otherwise shutdown because we are done
-     if (Get-WURebootStatus -Silent) {invoke-expression 'shutdown -r -t 0'} 
-     else {invoke-expression 'shutdown -s -t 0'}}
+    # Reboot if needed - otherwise shutdown because we are done
+    if (Get-WURebootStatus -Silent) 
+    {
+        Invoke-Expression 'shutdown -r -t 0';
+    } 
+    else
+    {
+        invoke-expression 'shutdown -s -t 0';
+    }
+};
 
 ### Sysprep script block
 $sysprepScriptBlock = {

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -275,23 +275,36 @@ function makeUnattendFile
     cleanupFile $filePath; $Unattend.Save($filePath);
 }
 
-Function createRunAndWaitVM ([string]$vhd, [string]$gen) {
-      # Function for whenever I have a VHD that is ready to run
-      new-vm $factoryVMName -MemoryStartupBytes 2048mb -VHDPath $vhd -Generation $Gen `
-                            -SwitchName $virtualSwitchName | Out-Null
-      set-vm -Name $factoryVMName -ProcessorCount 2
-      Start-VM $factoryVMName
+function createRunAndWaitVM 
+{
+    param
+    (
+        [string] $vhd, 
+        [string] $gen
+    );
+    
+    # Function for whenever I have a VHD that is ready to run
+    New-VM $factoryVMName -MemoryStartupBytes 2048mb -VHDPath $vhd -Generation $Gen -SwitchName $virtualSwitchName | Out-Null;
+    set-vm -Name $factoryVMName -ProcessorCount 2;
+    Start-VM $factoryVMName;
 
-      # Give the VM a moment to start before we start checking for it to stop
-      Sleep -Seconds 10
+    # Give the VM a moment to start before we start checking for it to stop
+    Sleep -Seconds 10;
 
-      # Wait for the VM to be stopped for a good solid 5 seconds
-      do {$state1 = (Get-VM | ? name -eq $factoryVMName).State; sleep -Seconds 5
-          $state2 = (Get-VM | ? name -eq $factoryVMName).State; sleep -Seconds 5} 
-          until (($state1 -eq "Off") -and ($state2 -eq "Off"))
+    # Wait for the VM to be stopped for a good solid 5 seconds
+    do
+    {
+        $state1 = (Get-VM | ? name -eq $factoryVMName).State;
+        Start-Sleep -Seconds 5;
+        
+        $state2 = (Get-VM | ? name -eq $factoryVMName).State;
+        Start-Sleep -Seconds 5;
+    } 
+    until (($state1 -eq "Off") -and ($state2 -eq "Off"))
 
-      # Clean up the VM
-      Remove-VM $factoryVMName -Force}
+    # Clean up the VM
+    Remove-VM $factoryVMName -Force;
+}
 
 Function MountVHDandRunBlock ([string]$vhd, [scriptblock]$block) { 
       # This function mounts a VHD, runs a script block and unmounts the VHD.

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -222,7 +222,7 @@ Function createRunAndWaitVM ([string]$vhd, [string]$gen) {
 Function MountVHDandRunBlock ([string]$vhd, [scriptblock]$block) { 
       # This function mounts a VHD, runs a script block and unmounts the VHD.
       # Drive letter of the mounted VHD is stored in $driveLetter - can be used by script blocks
-      $driveLetter = (Mount-VHD $vhd –passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter
+      $driveLetter = (Mount-VHD $vhd -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter
       &$block
       dismount-vhd $vhd
 
@@ -362,7 +362,7 @@ Function RunTheFactory([string]$FriendlyName, `
 
        # Mount the VHD
        logger $FriendlyName "Mount the differencing disk"
-       $driveLetter = (Mount-VHD $updateVHD –passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter
+       $driveLetter = (Mount-VHD $updateVHD -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter
        
        # Check to see if changes were made
        logger $FriendlyName "Check to see if there were any updates"

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -377,15 +377,18 @@ $sysprepScriptBlock = {
 
 ### Post Sysprep script block
 $postSysprepScriptBlock = {
-     # Remove autorun key if it exists
-     Get-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run | ? Property -like Unattend* | Remove-Item
+    # Remove autorun key if it exists
+    Get-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Run | ? Property -like Unattend* | Remove-Item;
 
-     # Clean up unattend file if it is there
-     if (test-path "$ENV:SystemDrive\Unattend.xml") {Remove-Item -Force "$ENV:SystemDrive\Unattend.xml"}
+    # Clean up unattend file if it is there
+    if (Test-Path "$ENV:SystemDrive\Unattend.xml") 
+    {
+        Remove-Item -Force "$ENV:SystemDrive\Unattend.xml";
+    }
      
-     # Put any code you want to run Post sysprep here
-     invoke-expression 'shutdown -r -t 0'
-     }
+    # Put any code you want to run Post sysprep here
+    Invoke-Expression 'shutdown -r -t 0';
+};
 
 # This is the main function of this script
 function RunTheFactory

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -588,17 +588,17 @@ function RunTheFactory
     }
 }
 
-RunTheFactory -FriendlyName "Windows Server 2012 R2 DataCenter with GUI" -ISOFile $2012R2Image -ProductKey $Windows2012R2Key -SKUEdition "ServerDataCenter"
-RunTheFactory -FriendlyName "Windows Server 2012 R2 DataCenter Core" -ISOFile $2012R2Image -ProductKey $Windows2012R2Key -SKUEdition "ServerDataCenterCore"
-RunTheFactory -FriendlyName "Windows Server 2012 R2 DataCenter with GUI - Gen 2" -ISOFile $2012R2Image -ProductKey $Windows2012R2Key -SKUEdition "ServerDataCenter" -Generation2
-RunTheFactory -FriendlyName "Windows Server 2012 R2 DataCenter Core - Gen 2" -ISOFile $2012R2Image -ProductKey $Windows2012R2Key -SKUEdition "ServerDataCenterCore" -Generation2
-RunTheFactory -FriendlyName "Windows Server 2012 DataCenter with GUI" -ISOFile $2012Image -ProductKey $Windows2012Key -SKUEdition "ServerDataCenter"
-RunTheFactory -FriendlyName "Windows Server 2012 DataCenter Core" -ISOFile $2012Image -ProductKey $Windows2012Key -SKUEdition "ServerDataCenterCore"
-RunTheFactory -FriendlyName "Windows Server 2012 DataCenter with GUI - Gen 2" -ISOFile $2012Image -ProductKey $Windows2012Key -SKUEdition "ServerDataCenter" -Generation2
-RunTheFactory -FriendlyName "Windows Server 2012 DataCenter Core - Gen 2" -ISOFile $2012Image -ProductKey $Windows2012Key -SKUEdition "ServerDataCenterCore" -Generation2
-RunTheFactory -FriendlyName "Windows 8.1 Professional" -ISOFile $81x64Image -ProductKey $Windows81Key -SKUEdition "Professional" -desktop $true
-RunTheFactory -FriendlyName "Windows 8.1 Professional - Gen 2" -ISOFile $81x64Image -ProductKey $Windows81Key -SKUEdition "Professional" -Generation2  -desktop $true
-RunTheFactory -FriendlyName "Windows 8.1 Professional - 32 bit" -ISOFile $81x86Image -ProductKey $Windows81Key -SKUEdition "Professional" -desktop $true -is32bit $true
-RunTheFactory -FriendlyName "Windows 8 Professional" -ISOFile $8x64Image -ProductKey $Windows8Key -SKUEdition "Professional" -desktop $true
-RunTheFactory -FriendlyName "Windows 8 Professional - Gen 2" -ISOFile $8x64Image -ProductKey $Windows8Key -SKUEdition "Professional" -Generation2 -desktop $true
-RunTheFactory -FriendlyName "Windows 8 Professional - 32 bit" -ISOFile $8x86Image -ProductKey $Windows8Key -SKUEdition "Professional" -desktop $true -is32bit $true
+RunTheFactory -FriendlyName "Windows Server 2012 R2 DataCenter with GUI" -ISOFile $2012R2Image -ProductKey $Windows2012R2Key -SKUEdition "ServerDataCenter";
+RunTheFactory -FriendlyName "Windows Server 2012 R2 DataCenter Core" -ISOFile $2012R2Image -ProductKey $Windows2012R2Key -SKUEdition "ServerDataCenterCore";
+RunTheFactory -FriendlyName "Windows Server 2012 R2 DataCenter with GUI - Gen 2" -ISOFile $2012R2Image -ProductKey $Windows2012R2Key -SKUEdition "ServerDataCenter" -Generation2;
+RunTheFactory -FriendlyName "Windows Server 2012 R2 DataCenter Core - Gen 2" -ISOFile $2012R2Image -ProductKey $Windows2012R2Key -SKUEdition "ServerDataCenterCore" -Generation2;
+RunTheFactory -FriendlyName "Windows Server 2012 DataCenter with GUI" -ISOFile $2012Image -ProductKey $Windows2012Key -SKUEdition "ServerDataCenter";
+RunTheFactory -FriendlyName "Windows Server 2012 DataCenter Core" -ISOFile $2012Image -ProductKey $Windows2012Key -SKUEdition "ServerDataCenterCore";
+RunTheFactory -FriendlyName "Windows Server 2012 DataCenter with GUI - Gen 2" -ISOFile $2012Image -ProductKey $Windows2012Key -SKUEdition "ServerDataCenter" -Generation2;
+RunTheFactory -FriendlyName "Windows Server 2012 DataCenter Core - Gen 2" -ISOFile $2012Image -ProductKey $Windows2012Key -SKUEdition "ServerDataCenterCore" -Generation2;
+RunTheFactory -FriendlyName "Windows 8.1 Professional" -ISOFile $81x64Image -ProductKey $Windows81Key -SKUEdition "Professional" -desktop $true;
+RunTheFactory -FriendlyName "Windows 8.1 Professional - Gen 2" -ISOFile $81x64Image -ProductKey $Windows81Key -SKUEdition "Professional" -Generation2  -desktop $true;
+RunTheFactory -FriendlyName "Windows 8.1 Professional - 32 bit" -ISOFile $81x86Image -ProductKey $Windows81Key -SKUEdition "Professional" -desktop $true -is32bit $true;
+RunTheFactory -FriendlyName "Windows 8 Professional" -ISOFile $8x64Image -ProductKey $Windows8Key -SKUEdition "Professional" -desktop $true;
+RunTheFactory -FriendlyName "Windows 8 Professional - Gen 2" -ISOFile $8x64Image -ProductKey $Windows8Key -SKUEdition "Professional" -Generation2 -desktop $true;
+RunTheFactory -FriendlyName "Windows 8 Professional - 32 bit" -ISOFile $8x86Image -ProductKey $Windows8Key -SKUEdition "Professional" -desktop $true -is32bit $true;

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -306,16 +306,23 @@ function createRunAndWaitVM
     Remove-VM $factoryVMName -Force;
 }
 
-Function MountVHDandRunBlock ([string]$vhd, [scriptblock]$block) { 
-      # This function mounts a VHD, runs a script block and unmounts the VHD.
-      # Drive letter of the mounted VHD is stored in $driveLetter - can be used by script blocks
-      $driveLetter = (Mount-VHD $vhd -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter
-      &$block
-      dismount-vhd $vhd
+function MountVHDandRunBlock 
+{
+    param
+    (
+        [string]$vhd, 
+        [scriptblock]$block
+    );
+     
+    # This function mounts a VHD, runs a script block and unmounts the VHD.
+    # Drive letter of the mounted VHD is stored in $driveLetter - can be used by script blocks
+    $driveLetter = (Mount-VHD $vhd -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter;
+    & $block;
+    Dismount-VHD $vhd;
 
-      # Wait 2 seconds for activity to clean up
-      Start-Sleep -Seconds 2
-      }
+    # Wait 2 seconds for activity to clean up
+    Start-Sleep -Seconds 2;
+}
 
 ### Update script block
 $updateCheckScriptBlock = {

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -184,12 +184,19 @@ function CSVLogger {
     }
 }
 
-function Logger ([string]$systemName, [string]$message)
-    {# Function for displaying formatted log messages.  Also displays time in minutes since the script was started
-     write-host (Get-Date).ToShortTimeString() -ForegroundColor Cyan -NoNewline
-     write-host " - [" -ForegroundColor White -NoNewline
-     write-host $systemName -ForegroundColor Yellow -NoNewline
-     write-Host "]::$($message)" -ForegroundColor White}
+function Logger {
+    param
+    (
+        [string]$systemName,
+        [string]$message
+    );
+
+    # Function for displaying formatted log messages.  Also displays time in minutes since the script was started
+    write-host (Get-Date).ToShortTimeString() -ForegroundColor Cyan -NoNewline;
+    write-host " - [" -ForegroundColor White -NoNewline;
+    write-host $systemName -ForegroundColor Yellow -NoNewline;
+    write-Host "]::$($message)" -ForegroundColor White;
+}
 
 # Helper function for no error file cleanup
 Function cleanupFile ([string]$file) {if (test-path $file) {Remove-Item $file}}

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -199,7 +199,18 @@ function Logger {
 }
 
 # Helper function for no error file cleanup
-Function cleanupFile ([string]$file) {if (test-path $file) {Remove-Item $file}}
+function cleanupFile
+{
+    param
+    (
+        [string]$file
+    )
+    
+    if (Test-Path $file) 
+    {
+        Remove-Item $file
+    }
+}
 
 function GetUnattendChunk ([string]$pass, [string]$component, [xml]$unattend) 
     {# Helper function that returns one component chunk from the Unattend XML data structure


### PR DESCRIPTION
Hi Ben,

This pull requests cleans up left overs from the .vhdx. The File Convert-WindowsImageInfo.txt is removed when the base image is created first so this will not "fix" images already created.

The folder \Bits is removed within the $postSysprepScriptBlock when the cycle is not creating a genericly sysprepped image. In that case the folder is removed from the .vhd directly when sysprep was executed.

Thanks & BR
Chris
