### PR TITLE
Externalize configuration

### DIFF
--- a/Image-Factory/Factory.config.ps1
+++ b/Image-Factory/Factory.config.ps1
@@ -11,7 +11,7 @@
 #>
 
 $Global:IF_WorkingDirectory = "D:\ImageFactory";
-$Global:IF_ResourceDirectory = "$($Global:IF_WorkingDirectory)\resources\Bits";
+$Global:IF_ResourceDirectory = "$($Global:IF_WorkingDirectory)\resources";
 $Global:IF_CsvFilePath = "$($Global:IF_WorkingDirectory)\Share\Details.csv";
 $Global:IF_VirtualMachineName = "Factory VM";
 $Global:IF_VirtualSwitchName = "Virtual Switch";

--- a/Image-Factory/Factory.config.ps1
+++ b/Image-Factory/Factory.config.ps1
@@ -1,0 +1,180 @@
+<#
+	NOTES
+		This configuration file is merged with an xml based configuration
+		(Factory.ps1.config) if one exists. This configuration takes precedence
+		over values specified in the xml based configuration.
+
+		Please make sure that the $Global:IF_* configuration values are only specified 
+		in either file (if you use both in parallel). This does not apply to the 
+		$Global:IF_Images collection as it is merge. This means you can add image 
+		definitions within this configuration as well as in the xml based configuration.
+#>
+
+$Global:IF_WorkingDirectory = "D:\ImageFactory";
+$Global:IF_ResourceDirectory = "$($Global:IF_WorkingDirectory)\resources\Bits";
+$Global:IF_CsvFilePath = "$($Global:IF_WorkingDirectory)\Share\Details.csv";
+$Global:IF_VirtualMachineName = "Factory VM";
+$Global:IF_VirtualSwitchName = "Virtual Switch";
+$Global:IF_Organization = "The Power Elite";
+$Global:IF_Owner = "Ben Armstrong";
+$Global:IF_Timezone = "Pacific Standard Time";
+$Global:IF_AdminPassword = "P@ssw0rd";
+$Global:IF_UserPassword = "P@ssw0rd";
+
+<#
+	Examples
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows Server 2012 R2 DataCenter with GUI"
+		Path = ""
+		Key = ""
+		Edition = "ServerDataCenter"
+		IsDesktop = $false
+		Is32Bit = $false
+		VmGeneration = 2
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows Server 2012 R2 DataCenter Core"
+		Path = ""
+		Key = ""
+		Edition = "ServerDataCenterCore"
+		IsDesktop = $false
+		Is32Bit = $false
+		VmGeneration = 1
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows Server 2012 R2 with GUI - Gen 2"
+		Path = ""
+		Key = ""
+		Edition = "ServerDataCenter"
+		IsDesktop = $false
+		Is32Bit = $false
+		VmGeneration = 2
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows Server 2012 R2 Core - Gen 2"
+		Path = ""
+		Key = ""
+		Edition = "ServerDataCenterCore"
+		IsDesktop = $false
+		Is32Bit = $false
+		VmGeneration = 2
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows Server 2012 DataCenter with GUI"
+		Path = ""
+		Key = ""
+		Edition = "ServerDataCenter"
+		IsDesktop = $false
+		Is32Bit = $false
+		VmGeneration = 1
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows Server 2012 DataCenter Core"
+		Path = ""
+		Key = ""
+		Edition = "ServerDataCenterCore"
+		IsDesktop = $false
+		Is32Bit = $false
+		VmGeneration = 1
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows Server 2012 with GUI - Gen 2"
+		Path = ""
+		Key = ""
+		Edition = "ServerDataCenter"
+		IsDesktop = $false
+		Is32Bit = $false
+		VmGeneration = 2
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows Server 2012 Core - Gen 2"
+		Path = ""
+		Key = ""
+		Edition = "ServerDataCenterCore"
+		IsDesktop = $false
+		Is32Bit = $false
+		VmGeneration = 2
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows 8.1 Professional"
+		Path = ""
+		Key = ""
+		Edition = "Professional"
+		IsDesktop = $true
+		Is32Bit = $false
+		VmGeneration = 1
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows 8.1 Professional - Gen 2"
+		Path = ""
+		Key = ""
+		Edition = "Professional"
+		IsDesktop = $true
+		Is32Bit = $false
+		VmGeneration = 2
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows 8.1 Professional - 32 bit"
+		Path = ""
+		Key = ""
+		Edition = "Professional"
+		IsDesktop = $true
+		Is32Bit = $true
+		VmGeneration = 1
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows 8 Professional"
+		Path = ""
+		Key = ""
+		Edition = "Professional"
+		IsDesktop = $true
+		Is32Bit = $false
+		VmGeneration = 1
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows 8 Professional - Gen 2"
+		Path = ""
+		Key = ""
+		Edition = "Professional"
+		IsDesktop = $true
+		Is32Bit = $false
+		VmGeneration = 2
+		GenericSysprep = $false
+	};
+
+	$Global:IF_Images += New-Object PSObject -Property @{
+		Name = "Windows 8 Professional - 32 bit"
+		Path = ""
+		Key = ""
+		Edition = "Professional"
+		IsDesktop = $true
+		Is32Bit = $true
+		VmGeneration = 1
+		GenericSysprep = $false
+	};
+#>

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -567,6 +567,7 @@ function RunTheFactory
 
 		checkPath "$($WorkingDirectory)";
 		checkPath "$($ResourceDirectory)";
+        checkPath "$($ResourceDirectory)\bits";
 
         # Setup a bunch of variables 
         $sysprepNeeded = $true;
@@ -626,7 +627,7 @@ function RunTheFactory
                 cleanupFile -file "$($driveLetter):\Convert-WindowsImageInfo.txt";
 
                 # Copy ResourceDirectory in
-                Copy-Item ($ResourceDirectory) -Destination ($driveLetter + ":\") -Recurse;
+                Copy-Item "$($ResourceDirectory)\Bits" -Destination ($driveLetter + ":\") -Recurse;
             
                 # Create first logon script
                 $updateCheckScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -417,7 +417,7 @@ function Get-ScriptName
 	process
 	{
 		$invocation = (Get-Variable MyInvocation -Scope 2).Value;
-		return Split-Path $invocation.MyCommand.Name;
+		return $invocation.MyCommand.Name;
 	}	
 }
 
@@ -551,7 +551,7 @@ function RunTheFactory
 
 	process
 	{
-    logger $FriendlyName "Starting a new cycle!"
+        logger $FriendlyName "Starting a new cycle!"
 
 		# Check parameter values and/or retrieve global override
 		$WorkingDirectory = Get-ParameterOrGlobalValue -Name "WorkingDirectory" -Value $WorkingDirectory;
@@ -568,212 +568,212 @@ function RunTheFactory
 		checkPath "$($WorkingDirectory)";
 		checkPath "$($ResourceDirectory)";
 
-    # Setup a bunch of variables 
-    $sysprepNeeded = $true;
+        # Setup a bunch of variables 
+        $sysprepNeeded = $true;
 		$baseVHD = "$($WorkingDirectory)\bases\$($FriendlyName)-base.vhdx";
 		$updateVHD = "$($WorkingDirectory)\$($FriendlyName)-update.vhdx";
 		$sysprepVHD = "$($WorkingDirectory)\$($FriendlyName)-sysprep.vhdx";
 		$finalVHD = "$($WorkingDirectory)\share\$($FriendlyName).vhdx";
    
-    $VHDPartitionStyle = "MBR";
-    $Gen = 1;
-    if ($Generation2) 
-    {
-        $VHDPartitionStyle = "GPT";
-        $Gen = 2;
-    }
+        $VHDPartitionStyle = "MBR";
+        $Gen = 1;
+        if ($Generation2) 
+        {
+            $VHDPartitionStyle = "GPT";
+            $Gen = 2;
+        }
 
-    logger $FriendlyName "Checking for existing Factory VM";
+        logger $FriendlyName "Checking for existing Factory VM";
 
-    # Check if there is already a factory VM - and kill it if there is
-		    if ((Get-VM | ? Name -eq $VirtualMachineName).Count -gt 0)
-    {
-			    Stop-VM $VirtualMachineName -TurnOff -Confirm:$false -Passthru | Remove-VM -Force;
-    }
+        # Check if there is already a factory VM - and kill it if there is
+		        if ((Get-VM | ? Name -eq $VirtualMachineName).Count -gt 0)
+        {
+			        Stop-VM $VirtualMachineName -TurnOff -Confirm:$false -Passthru | Remove-VM -Force;
+        }
 
-    # Check for a base VHD
-    if (-not (test-path $baseVHD))
-    {
-        # No base VHD - we need to create one
-        logger $FriendlyName "No base VHD!";
+        # Check for a base VHD
+        if (-not (test-path $baseVHD))
+        {
+            # No base VHD - we need to create one
+            logger $FriendlyName "No base VHD!";
 
-        # Make unattend file
-        logger $FriendlyName "Creating unattend file for base VHD";
+            # Make unattend file
+            logger $FriendlyName "Creating unattend file for base VHD";
 
-        # Logon count is just "large number"
-			    makeUnattendFile -Organization $Organization -Owner $Owner -Timezone $Timezone -AdminPassword $AdminPassword -UserPassword $UserPassword `
-				    -key $ProductKey -logonCount "1000" -filePath "$($WorkingDirectory)\unattend.xml" -desktop $desktop -is32bit $is32bit;
+            # Logon count is just "large number"
+		    makeUnattendFile -Organization $Organization -Owner $Owner -Timezone $Timezone -AdminPassword $AdminPassword -UserPassword $UserPassword `
+			    -key $ProductKey -logonCount "1000" -filePath "$($WorkingDirectory)\unattend.xml" -desktop $desktop -is32bit $is32bit;
       
-        # Time to create the base VHD
-        logger $FriendlyName "Create base VHD using Convert-WindowsImage.ps1";
+            # Time to create the base VHD
+            logger $FriendlyName "Create base VHD using Convert-WindowsImage.ps1";
 
 		    ### Load Convert-WindowsImage
 		    . "$($ResourceDirectory)\Convert-WindowsImage.ps1";
         
-        $ConvertCommand = "Convert-WindowsImage";
-        $ConvertCommand = $ConvertCommand + " -SourcePath `"$ISOFile`" -VHDPath `"$baseVHD`"";
+            $ConvertCommand = "Convert-WindowsImage";
+            $ConvertCommand = $ConvertCommand + " -SourcePath `"$ISOFile`" -VHDPath `"$baseVHD`"";
             $ConvertCommand = $ConvertCommand + " -SizeBytes 80GB -VHDFormat VHDX -UnattendPath `"$($WorkingDirectory)\unattend.xml`"";
-        $ConvertCommand = $ConvertCommand + " -Edition $SKUEdition -VHDPartitionStyle $VHDPartitionStyle";
+            $ConvertCommand = $ConvertCommand + " -Edition $SKUEdition -VHDPartitionStyle $VHDPartitionStyle";
 
-        Invoke-Expression "& $ConvertCommand";
+            Invoke-Expression "& $ConvertCommand";
 
-        # Clean up unattend file - we don't need it any more
-        logger $FriendlyName "Remove unattend file now that that is done";
-			    cleanupFile "$($WorkingDirectory)\unattend.xml";
+            # Clean up unattend file - we don't need it any more
+            logger $FriendlyName "Remove unattend file now that that is done";
+		    cleanupFile "$($WorkingDirectory)\unattend.xml";
 
-        logger $FriendlyName "Mount VHD and copy bits in, also set startup file";
-        MountVHDandRunBlock $baseVHD {
-            cleanupFile -file "$($driveLetter):\Convert-WindowsImageInfo.txt";
+            logger $FriendlyName "Mount VHD and copy bits in, also set startup file";
+            MountVHDandRunBlock $baseVHD {
+                cleanupFile -file "$($driveLetter):\Convert-WindowsImageInfo.txt";
 
-            # Copy ResourceDirectory in
-            Copy-Item ($ResourceDirectory) -Destination ($driveLetter + ":\") -Recurse;
+                # Copy ResourceDirectory in
+                Copy-Item ($ResourceDirectory) -Destination ($driveLetter + ":\") -Recurse;
             
-            # Create first logon script
-            $updateCheckScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
+                # Create first logon script
+                $updateCheckScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
+            }
+
+            logger $FriendlyName "Create virtual machine, start it and wait for it to stop...";
+		    createRunAndWaitVM -VirtualMachineName $VirtualMachineName -VirtualSwitchName $VirtualSwitchName -vhd $baseVHD -gen $Gen;
+
+            # Remove Page file
+            logger $FriendlyName "Removing the page file";
+            MountVHDandRunBlock $baseVHD {
+                attrib -s -h "$($driveLetter):\pagefile.sys";
+                cleanupFile "$($driveLetter):\pagefile.sys";
+            }
+
+            # Compact the base file
+            logger $FriendlyName "Compacting the base file";
+            Optimize-VHD -Path $baseVHD -Mode Full;
         }
-
-        logger $FriendlyName "Create virtual machine, start it and wait for it to stop...";
-			    createRunAndWaitVM -VirtualMachineName $VirtualMachineName -VirtualSwitchName $VirtualSwitchName -vhd $baseVHD -gen $Gen;
-
-        # Remove Page file
-        logger $FriendlyName "Removing the page file";
-        MountVHDandRunBlock $baseVHD {
-            attrib -s -h "$($driveLetter):\pagefile.sys";
-            cleanupFile "$($driveLetter):\pagefile.sys";
-        }
-
-        # Compact the base file
-        logger $FriendlyName "Compacting the base file";
-        Optimize-VHD -Path $baseVHD -Mode Full;
-    }
-    else
-    {
-        # The base VHD existed - time to check if it needs an update
-        logger $FriendlyName "Base VHD exists - need to check for updates";
-
-        # create new diff to check for updates
-        logger $FriendlyName "Create new differencing disk to check for updates";
-        cleanupFile $updateVHD;
-        New-VHD -Path $updateVHD -ParentPath $baseVHD | Out-Null;
-
-        logger $FriendlyName "Copy login file for update check, also make sure flag file is cleared"
-        MountVHDandRunBlock $updateVHD {
-            # Make the UpdateCheck script the logon script, make sure update flag file is deleted before we start
-            cleanupFile "$($driveLetter):\Bits\changesMade.txt";
-            cleanupFile "$($driveLetter):\Bits\Logon.ps1";
-            $updateCheckScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
-        }
-
-        logger $FriendlyName "Create virtual machine, start it and wait for it to stop...";
-			    createRunAndWaitVM -VirtualMachineName $VirtualMachineName -VirtualSwitchName $VirtualSwitchName -vhd $updateVHD -gen $Gen;
-
-        # Mount the VHD
-        logger $FriendlyName "Mount the differencing disk";
-        $driveLetter = (Mount-VHD $updateVHD -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter;
-       
-        # Check to see if changes were made
-        logger $FriendlyName "Check to see if there were any updates";
-        if (Test-Path "$($driveLetter):\Bits\changesMade.txt") 
+        else
         {
-            cleanupFile "$($driveLetter):\Bits\changesMade.txt";
-            logger $FriendlyName "Updates were found";
-        }
-        else 
-        {
-            logger $FriendlyName "No updates were found"; 
-            $sysprepNeeded = $false;
-        }
+            # The base VHD existed - time to check if it needs an update
+            logger $FriendlyName "Base VHD exists - need to check for updates";
 
-        # Dismount
-        logger $FriendlyName "Dismount the differencing disk";
-        Dismount-VHD $updateVHD;
-
-        # Wait 2 seconds for activity to clean up
-        Start-Sleep -Seconds 2;
-
-        # If changes were made - merge them in.  If not, throw it away
-        if ($sysprepNeeded) 
-        {
-            logger $FriendlyName "Merge the differencing disk";
-            Merge-VHD -Path $updateVHD -DestinationPath $baseVHD;
-        }
-        else 
-        {
-            logger $FriendlyName "Delete the differencing disk"; 
-				    CSVLogger -CsvFile $CsvFilePath -VhdFile $finalVHD;
+            # create new diff to check for updates
+            logger $FriendlyName "Create new differencing disk to check for updates";
             cleanupFile $updateVHD;
+            New-VHD -Path $updateVHD -ParentPath $baseVHD | Out-Null;
+
+            logger $FriendlyName "Copy login file for update check, also make sure flag file is cleared"
+            MountVHDandRunBlock $updateVHD {
+                # Make the UpdateCheck script the logon script, make sure update flag file is deleted before we start
+                cleanupFile "$($driveLetter):\Bits\changesMade.txt";
+                cleanupFile "$($driveLetter):\Bits\Logon.ps1";
+                $updateCheckScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
+            }
+
+            logger $FriendlyName "Create virtual machine, start it and wait for it to stop...";
+		    createRunAndWaitVM -VirtualMachineName $VirtualMachineName -VirtualSwitchName $VirtualSwitchName -vhd $updateVHD -gen $Gen;
+
+            # Mount the VHD
+            logger $FriendlyName "Mount the differencing disk";
+            $driveLetter = (Mount-VHD $updateVHD -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter;
+       
+            # Check to see if changes were made
+            logger $FriendlyName "Check to see if there were any updates";
+            if (Test-Path "$($driveLetter):\Bits\changesMade.txt") 
+            {
+                cleanupFile "$($driveLetter):\Bits\changesMade.txt";
+                logger $FriendlyName "Updates were found";
+            }
+            else 
+            {
+                logger $FriendlyName "No updates were found"; 
+                $sysprepNeeded = $false;
+            }
+
+            # Dismount
+            logger $FriendlyName "Dismount the differencing disk";
+            Dismount-VHD $updateVHD;
+
+            # Wait 2 seconds for activity to clean up
+            Start-Sleep -Seconds 2;
+
+            # If changes were made - merge them in.  If not, throw it away
+            if ($sysprepNeeded) 
+            {
+                logger $FriendlyName "Merge the differencing disk";
+                Merge-VHD -Path $updateVHD -DestinationPath $baseVHD;
+            }
+            else 
+            {
+                logger $FriendlyName "Delete the differencing disk"; 
+			    CSVLogger -CsvFile $CsvFilePath -VhdFile $finalVHD;
+                cleanupFile $updateVHD;
+            }
         }
-    }
 
-    # Final Check - if the final VHD is missing - we need to sysprep and make it
-    if (-not (Test-Path $finalVHD)) 
-    {
-        $sysprepNeeded = $true;
-    }
+        # Final Check - if the final VHD is missing - we need to sysprep and make it
+        if (-not (Test-Path $finalVHD)) 
+        {
+            $sysprepNeeded = $true;
+        }
 
-    if ($sysprepNeeded)
-    {
-        # create new diff to sysprep
-        logger $FriendlyName "Need to run Sysprep";
-        logger $FriendlyName "Creating differencing disk";
-        cleanupFile $sysprepVHD; new-vhd -Path $sysprepVHD -ParentPath $baseVHD | Out-Null;
+        if ($sysprepNeeded)
+        {
+            # create new diff to sysprep
+            logger $FriendlyName "Need to run Sysprep";
+            logger $FriendlyName "Creating differencing disk";
+            cleanupFile $sysprepVHD; new-vhd -Path $sysprepVHD -ParentPath $baseVHD | Out-Null;
 
-        logger $FriendlyName "Mount the differencing disk and copy in files";
-        MountVHDandRunBlock $sysprepVHD {
-            $sysprepScriptBlockString = $sysprepScriptBlock | Out-String;
+            logger $FriendlyName "Mount the differencing disk and copy in files";
+            MountVHDandRunBlock $sysprepVHD {
+                $sysprepScriptBlockString = $sysprepScriptBlock | Out-String;
 
-            if($GenericSysprep)
-            {
-                $sysprepScriptBlockString = $sysprepScriptBlockString.Replace(' `/unattend:"$unattendedXmlPath"', "");
-            }
-            else
-            {
-                # Make unattend file
-					    makeUnattendFile -Organization $Organization -Owner $Owner -Timezone $Timezone -AdminPassword $AdminPassword -UserPassword $UserPassword `
-						    -key $ProductKey -logonCount "1" -filePath "$($driveLetter):\Bits\unattend.xml" -desktop $desktop -is32bit $is32bit;
-            }
+                if($GenericSysprep)
+                {
+                    $sysprepScriptBlockString = $sysprepScriptBlockString.Replace(' `/unattend:"$unattendedXmlPath"', "");
+                }
+                else
+                {
+                    # Make unattend file
+				    makeUnattendFile -Organization $Organization -Owner $Owner -Timezone $Timezone -AdminPassword $AdminPassword -UserPassword $UserPassword `
+					    -key $ProductKey -logonCount "1" -filePath "$($driveLetter):\Bits\unattend.xml" -desktop $desktop -is32bit $is32bit;
+                }
             
-            # Make the logon script
-            cleanupFile "$($driveLetter):\Bits\Logon.ps1";
-            $sysprepScriptBlockString | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
-        }
-
-        logger $FriendlyName "Create virtual machine, start it and wait for it to stop...";
-			    createRunAndWaitVM -VirtualMachineName $VirtualMachineName -VirtualSwitchName $VirtualSwitchName -vhd $sysprepVHD -gen $Gen;
-
-        logger $FriendlyName "Mount the differencing disk and cleanup files";
-        MountVHDandRunBlock $sysprepVHD {
-            cleanupFile "$($driveLetter):\Bits\unattend.xml";
-            cleanupFile "$($driveLetter):\Bits\Logon.ps1";
-
-            if(-not $GenericSysprep)
-            {
                 # Make the logon script
-                $postSysprepScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
+                cleanupFile "$($driveLetter):\Bits\Logon.ps1";
+                $sysprepScriptBlockString | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
             }
-            else
-            {
-                # Cleanup \Bits as the postSysprepScriptBlock is not run anymore
-                cleanupFile "$($driveLetter):\Bits";
+
+            logger $FriendlyName "Create virtual machine, start it and wait for it to stop...";
+			        createRunAndWaitVM -VirtualMachineName $VirtualMachineName -VirtualSwitchName $VirtualSwitchName -vhd $sysprepVHD -gen $Gen;
+
+            logger $FriendlyName "Mount the differencing disk and cleanup files";
+            MountVHDandRunBlock $sysprepVHD {
+                cleanupFile "$($driveLetter):\Bits\unattend.xml";
+                cleanupFile "$($driveLetter):\Bits\Logon.ps1";
+
+                if(-not $GenericSysprep)
+                {
+                    # Make the logon script
+                    $postSysprepScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
+                }
+                else
+                {
+                    # Cleanup \Bits as the postSysprepScriptBlock is not run anymore
+                    cleanupFile "$($driveLetter):\Bits";
+                }
             }
-        }
 
-        # Remove Page file
-        logger $FriendlyName "Removing the page file";
-        MountVHDandRunBlock $sysprepVHD {
-            attrib -s -h "$($driveLetter):\pagefile.sys";
-            cleanupFile "$($driveLetter):\pagefile.sys";
-        }
+            # Remove Page file
+            logger $FriendlyName "Removing the page file";
+            MountVHDandRunBlock $sysprepVHD {
+                attrib -s -h "$($driveLetter):\pagefile.sys";
+                cleanupFile "$($driveLetter):\pagefile.sys";
+            }
 
-        # Produce the final disk
-        cleanupFile $finalVHD;
-        logger $FriendlyName "Convert differencing disk into pristine base image";
-        Convert-VHD -Path $sysprepVHD -DestinationPath $finalVHD -VHDType Dynamic;
-        logger $FriendlyName "Delete differencing disk";
+            # Produce the final disk
+            cleanupFile $finalVHD;
+            logger $FriendlyName "Convert differencing disk into pristine base image";
+            Convert-VHD -Path $sysprepVHD -DestinationPath $finalVHD -VHDType Dynamic;
+            logger $FriendlyName "Delete differencing disk";
 		    CSVLogger -CsvFile $CsvFilePath -VhdFile $finalVHD -Sysprepped;
-        cleanupFile $sysprepVHD;
+            cleanupFile $sysprepVHD;
+        }
     }
-}
 }
 
 try

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -567,7 +567,6 @@ function RunTheFactory
 
 		checkPath "$($WorkingDirectory)";
 		checkPath "$($ResourceDirectory)";
-        checkPath "$($ResourceDirectory)\bits";
 
         # Setup a bunch of variables 
         $sysprepNeeded = $true;

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -365,7 +365,7 @@ function Import-Configuration
 		$psConfigPath = "$($path)\$($scriptName.Replace(".ps1", "config.ps1"))";
 		$xmlConfigPath = "$($path)\$($scriptName).config";
 
-		$Global:IF_Images = @{};
+		$Global:IF_Images = @();
 
 		if(Test-Path -Path $xmlConfigPath)
 		{
@@ -782,23 +782,40 @@ try
 	Import-Configuration;
 
 	# Main processing loop
-	foreach($image in $Global:IF_Images)
-	{
-		$isDesktop = [bool]::Parse($image.IsDesktop);
-		$is32Bit = [bool]::Parse($image.Is32Bit);
-		$genericSysprep = [bool]::Parse($image.GenericSysprep);
+    if($Global:IF_Images -ne $null -and $Global:IF_Images.Count -gt 0)
+    {
+	    foreach($image in $Global:IF_Images)
+	    {
+		    $isDesktop = [bool]::Parse($image.IsDesktop);
+            if(-not [string]::IsNullOrEmpty($image.IsDesktop))
+            {
+		        $isDesktop = [bool]::Parse($image.IsDesktop);
+            }
+            
+            $is32Bit = $false;
+            if(-not [string]::IsNullOrEmpty($image.Is32Bit))
+            {
+		        $is32Bit = [bool]::Parse($image.Is32Bit);
+            }
+		    
+            $genericSysprep = $false;
+            if(-not [string]::IsNullOrEmpty($image.GenericSysprep))
+            {
+                $genericSysprep = [bool]::Parse($image.GenericSysprep);
+            }
 
-		if($image.VmGeneration -eq 2)
-		{
-			RunTheFactory -FriendlyName $image.Name -ISOFile $image.Path -ProductKey $image.Key -SKUEdition $image.Edition `
-				-desktop $isDesktop -is32bit $is32Bit -GenericSysprep $genericSysprep -Generation2;
-		}
-		else
-		{
-			RunTheFactory -FriendlyName $image.Name -ISOFile $image.Path -ProductKey $image.Key -SKUEdition $image.Edition `
-				-desktop $isDesktop -is32bit $is32Bit -GenericSysprep $genericSysprep;
-		}
-	}
+		    if($image.VmGeneration -eq 2)
+		    {
+			    RunTheFactory -FriendlyName $image.Name -ISOFile $image.Path -ProductKey $image.Key -SKUEdition $image.Edition `
+				    -desktop $isDesktop -is32bit $is32Bit -GenericSysprep $genericSysprep -Generation2;
+		    }
+		    else
+		    {
+			    RunTheFactory -FriendlyName $image.Name -ISOFile $image.Path -ProductKey $image.Key -SKUEdition $image.Edition `
+				    -desktop $isDesktop -is32bit $is32Bit -GenericSysprep $genericSysprep;
+		    }
+	    }
+    }
 }
 catch
 {

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -377,7 +377,7 @@ function Import-Configuration
 				{
 					if($section -eq "appSettings")
 					{
-						Set-Variable -Name "IF_$($node.Key)" -Value $node.Value -Force;
+						Set-Variable -Name "IF_$($node.Key)" -Scope "Global" -Value $node.Value -Force;
 					}
 					elseif($section -eq "ImageFactory.Images")
 					{

--- a/Image-Factory/Factory.ps1.config
+++ b/Image-Factory/Factory.ps1.config
@@ -13,7 +13,7 @@
 <configuration>
   <appSettings>
     <add key="WorkingDirectory" value="D:\ImageFactory" />
-    <add key="ResourcesDirectory" value="D:\ImageFactory\resources\Bits" />
+    <add key="ResourceDirectory" value="D:\ImageFactory\resources\Bits" />
     <add key="CsvFilePath" value="D:\ImageFactory\share\Images.csv" />
     <add key="VirtualMachineName" value="Factory VM" />
     <add key="VirtualSwitchName" value="Factory Switch" />

--- a/Image-Factory/Factory.ps1.config
+++ b/Image-Factory/Factory.ps1.config
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  This configuration file is merged with a dot-sourced .ps1 configuration 
+  (Factory.config.ps1) if one exists. The dot-sourced .ps1 configuration
+  akes precendence over values contained within the <appSettings> block
+  in this file.
+      
+	Please make sure that the $Global:IF_* configuration values are only specified 
+	in either file (if you use both in parallel). This does not apply to the 
+	$Global:IF_Images collection as it is merge. This means you can add image 
+	definitions within this configuration as well as in the xml based configuration.
+-->
+<configuration>
+  <appSettings>
+    <add key="WorkingDirectory" value="D:\ImageFactory" />
+    <add key="ResourcesDirectory" value="D:\ImageFactory\resources\Bits" />
+    <add key="CsvFilePath" value="D:\ImageFactory\share\Images.csv" />
+    <add key="VirtualMachineName" value="Factory VM" />
+    <add key="VirtualSwitchName" value="Factory Switch" />
+    <add key="Organization" value="The Power Elite"/>
+    <add key="Owner" value="Ben Armstrong"/>
+    <add key="Timezone" value="Pacific Standard Time"/>
+    <add key="AdminPassword" value="P@ssw0rd" />
+    <add key="UserPassword" value="P@ssw0rd" />
+  </appSettings>
+  <ImageFactory.Images>
+    <!--
+      <add Name="" Path="" Key="" Edition="" IsDesktop="" IsDesktop="" Is32Bit="" VmGeneration="" GenericSysprep="" />
+      
+      Name - Friendly name for the image
+      Path - Path to the .iso/.wim file
+      Key - Product key
+      Edition - Which edition should be taken (e.g. ServerStandard, ServerDataCenter)
+      IsDesktop - Whether this is an desktop OS or server OS
+      Is32Bit - Whether this is a 32-bit or 64-bit installation
+      VmGeneration - Whether to create a generation 1 or generation 2 VM
+      GenericSysprep - Whether the resulting image is used with VMM, PDT or not
+      
+      Examples:
+      
+      <add Name="Windows Server 2012 R2 DataCenter with GUI" Path="" Key="" Edition="ServerDataCenter" IsDesktop="false" Is32Bit="false" />
+      <add Name="Windows Server 2012 R2 DataCenter Core" Path="" Key="" Edition="ServerDataCenterCore" IsDesktop="false" Is32Bit="false" />
+      <add Name="Windows Server 2012 R2 DataCenter with GUI - Gen 2" Path="" Key="" Edition="ServerDataCenter" IsDesktop="false" Is32Bit="false" VmGeneration="2" />
+      <add Name="Windows Server 2012 R2 DataCenter Core - Gen 2" Path="" Key="" Edition="ServerDataCenterCore" IsDesktop="false" Is32Bit="false" VmGeneration="2" />
+      <add Name="Windows Server 2012 DataCenter with GUI" Path="" Key="" Edition="ServerDataCenter" IsDesktop="false" Is32Bit="false" />
+      <add Name="Windows Server 2012 DataCenter Core" Path="" Key="" Edition="ServerDataCenterCore" IsDesktop="false" Is32Bit="false" />
+      <add Name="Windows Server 2012 DataCenter with GUI - Gen 2" Path="" Key="" Edition="ServerDataCenter" IsDesktop="false" Is32Bit="false" VmGeneration="2" />
+      <add Name="Windows Server 2012 DataCenter Core - Gen 2" Path="" Key="" Edition="ServerDataCenterCore" IsDesktop="false" Is32Bit="false" VmGeneration="2" />
+      <add Name="Windows 8.1 Professional" Path="" Key="" Edition="Professional" IsDesktop="true" Is32Bit="false" />
+      <add Name="Windows 8.1 Professional - Gen 2" Path="" Key="" Edition="Professional" IsDesktop="true" Is32Bit="false" VmGeneration="2" />
+      <add Name="Windows 8.1 Professional - 32 bit" Path="" Key="" Edition="Professional" IsDesktop="true" Is32Bit="true" />
+      <add Name="Windows 8 Professional" Path="" Key="" Edition="Professional" IsDesktop="true" Is32Bit="false" />
+      <add Name="Windows 8 Professional - Gen 2" Path="" Key="" Edition="Professional" IsDesktop="true" Is32Bit="false" VmGeneration="2" />
+      <add Name="Windows 8 Professional - 32 bit" Path="" Key="" Edition="Professional" IsDesktop="true" Is32Bit="true" />
+    -->
+  </ImageFactory.Images>
+</configuration>

--- a/Image-Factory/Factory.ps1.config
+++ b/Image-Factory/Factory.ps1.config
@@ -13,7 +13,7 @@
 <configuration>
   <appSettings>
     <add key="WorkingDirectory" value="D:\ImageFactory" />
-    <add key="ResourceDirectory" value="D:\ImageFactory\resources\Bits" />
+    <add key="ResourceDirectory" value="D:\ImageFactory\resources" />
     <add key="CsvFilePath" value="D:\ImageFactory\share\Images.csv" />
     <add key="VirtualMachineName" value="Factory VM" />
     <add key="VirtualSwitchName" value="Factory Switch" />


### PR DESCRIPTION
Hi Ben,

With this pull request I extend on the externalization of the configuration to have everything out of the main processing loop. This way most common scenarios can be adressed (dot-sourcing of the script for individual automation, invocation of the script with either .xml or .ps1 configuration for automation or manual invocation). Furthermore when using xml the configuration could be validated (not implemented yet though).

From the readme:
- Extended the externalization of the configuration to use either .ps1 based configuration or .xml based configuration
- Extended the main function call to accept $Global configuration values to prevent variable pollution but still limit the number of parameters to be passed
- Implemented separate configurable directories/paths for working/resources/log file

BR
Chris
