### PR TITLE
Convert-WindowsImage.ps1 should reside in the resources directory along with all other resources

### DIFF
--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -459,8 +459,8 @@ function RunTheFactory
         MountVHDandRunBlock $baseVHD {
             cleanupFile -file "$($driveLetter):\Convert-WindowsImageInfo.txt";
 
-            # Copy ResourceDirectory in
-            Copy-Item ($ResourceDirectory) -Destination ($driveLetter + ":\") -Recurse;
+            # Copy PSWindowsUpdate to VHD
+            Copy-Item "$($ResourceDirectory)\PSWindowsUpdate" -Destination ($driveLetter + ":\") -Recurse;
             
             # Create first logon script
             $updateCheckScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -459,8 +459,8 @@ function RunTheFactory
         MountVHDandRunBlock $baseVHD {
             cleanupFile -file "$($driveLetter):\Convert-WindowsImageInfo.txt";
 
-            # Copy PSWindowsUpdate to VHD
-            Copy-Item "$($ResourceDirectory)\PSWindowsUpdate" -Destination ($driveLetter + ":\") -Recurse;
+            # Copy bits to VHD
+            Copy-Item "$($ResourceDirectory)\bits" -Destination ($driveLetter + ":\") -Recurse;
             
             # Create first logon script
             $updateCheckScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -4,7 +4,7 @@
 $startTime = get-date
 
 ### Load Convert-WindowsImage
-. "$($workingDir)\Convert-WindowsImage.ps1"
+. "$($workingDir)\resources\Convert-WindowsImage.ps1"
 
 ### Sysprep unattend XML
 $unattendSource = [xml]@"


### PR DESCRIPTION
Hi Ben,

This very small fix changes the location of Convert-WindowsImage.ps1 to the resouces\ directory as all dependencies should be located together.

Thanks & BR
Chris
