### PR TITLE
Test if ISO file exists before trying to convert

### DIFF
--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -433,6 +433,11 @@ function RunTheFactory
     # Check for a base VHD
     if (-not (test-path $baseVHD))
     {
+        if (-not (Test-Path $ISOFile)) {
+            logger $FriendlyName 'ISO/WIM file missing, skipping this product.'
+            return
+        }
+
         # No base VHD - we need to create one
         logger $FriendlyName "No base VHD!";
 


### PR DESCRIPTION
This makes the script skip the product if it can't find the ISO or WIM
file, instead of trying to go through the motions and generating tons of
errors.
