### PR TITLE
Check that paths and additional modules exist

### DIFF
--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -308,7 +308,12 @@ function createRunAndWaitVM
     );
     
     # Function for whenever I have a VHD that is ready to run
-    New-VM $factoryVMName -MemoryStartupBytes 2048mb -VHDPath $vhd -Generation $Gen -SwitchName $virtualSwitchName | Out-Null;
+    New-VM $factoryVMName -MemoryStartupBytes $VMMemory -VHDPath $vhd -Generation $Gen -SwitchName $virtualSwitchName -ErrorAction Stop| Out-Null
+
+    If($UseVLAN) {
+        Get-VMNetworkAdapter -VMName $factoryVMName | Set-VMNetworkAdapterVlan -Access -VlanId $VlanId
+    }
+
     set-vm -Name $factoryVMName -ProcessorCount 2;
     Start-VM $factoryVMName;
 

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -1,10 +1,54 @@
 # Load variables from a seperate file - this when you pull down the latest factory file you can keep your paths / product keys etc...
 . .\FactoryVariables.ps1
-
 $startTime = get-date
 
-### Load Convert-WindowsImage
-. "$($workingDir)\resources\Convert-WindowsImage.ps1"
+
+# Helper function to make sure that needed folders are present
+function checkPath
+{
+    param
+    (
+        [string] $path
+    )
+    if (!(Test-Path $path)) 
+    {
+        $null = md $path;
+    }
+}
+
+# Test that necessary paths and files exist
+# Don't create the workingDir automatically - if it doesn't exist, the variables probably need the be configured first.
+if(-not (Test-Path -Path $workingDir -PathType Container)) {
+  Throw "Working directory $workingDir does not exist - edit FactoryVariables.ps1 to configure script"
+}
+
+# Create folders in workingDir if they don't exist
+checkPath "$($workingdir)\Share"
+checkPath "$($workingdir)\Bases"
+checkPath "$($workingdir)\ISOs"
+checkPath "$($workingdir)\Resources"
+checkPath "$($workingdir)\Resources\bits"
+
+### Load Convert-WindowsImage - making sure it exists and is unblocked
+if(Test-Path -Path "$($workingDir)\resources\Convert-WindowsImage.ps1") {
+    . "$($workingDir)\resources\Convert-WindowsImage.ps1"
+    if(!(Get-Command Convert-WindowsImage -ErrorAction SilentlyContinue)) {
+        Write-Host -ForegroundColor Green 'Convert-WindowsImage.ps1 could not be loaded. Unblock the script or check execution policy'
+        Throw 'Convert-WindowsImage was not loaded'
+    }
+} else {
+    Write-Host -ForegroundColor Green 'Please download Convert-WindowsImage.ps1 and place in $($workingDir)\Resources\'
+    Write-Host -ForegroundColor Green "`nhttps://gallery.technet.microsoft.com/scriptcenter/Convert-WindowsImageps1-0fe23a8f`n"
+    Throw 'Missing Convert-WindowsImage.ps1 script'
+}
+
+# Check that PSWindowsUpdate module exists
+if(!(Test-Path -Path "$($workingDir)\Resources\bits\PSWindowsUpdate\PSWindowsUpdate.psm1")) {
+    Write-Host -ForegroundColor Green 'Please download PSWindowsUpdate and extract to $($workingDir)\Resources\bits'
+    Write-Host -ForegroundColor Green "`nhttps://gallery.technet.microsoft.com/scriptcenter/2d191bcd-3308-4edd-9de2-88dff796b0bc`n"
+    Throw 'Missing PSWindowsUpdate module'
+}
+
 
 ### Sysprep unattend XML
 $unattendSource = [xml]@"
@@ -190,18 +234,7 @@ function cleanupFile
     }
 }
 
-# Helper function to make sure that needed folders are present
-function checkPath
-{
-    param
-    (
-        [string] $path
-    )
-    if (!(Test-Path $path)) 
-    {
-        md $path;
-    }
-}
+
 
 function GetUnattendChunk 
 {
@@ -401,9 +434,6 @@ function RunTheFactory
         [switch]$Generation2,
         [bool] $GenericSysprep = $false
     );
-
-    checkPath "$($workingdir)\Share";
-    checkPath "$($workingdir)\Bases";
 
     logger $FriendlyName "Starting a new cycle!"
 

--- a/Image-Factory/FactoryVariables.ps1
+++ b/Image-Factory/FactoryVariables.ps1
@@ -1,14 +1,26 @@
 # Seperate file for variables - this when you pull down the latest factory file you can keep your paths / product keys etc...
 $workingDir = "C:\FactoryTest"
 $logFile = "$($workingDir)\Share\Details.csv"
-$factoryVMName = "Factory VM"
-$virtualSwitchName = "Virtual Switch"
-$ResourceDirectory = "$($workingDir)\Resources\Bits" 
+$ResourceDirectory = "$($workingDir)\Resources" 
 $Organization = "The Power Elite"
 $Owner = "Ben Armstrong"
 $Timezone = "Pacific Standard Time"
 $adminPassword = "P@ssw0rd"
 $userPassword = "P@ssw0rd"
+
+# VM Settings
+    # Name of the VM - make sure this does not conflict with any existing virtual machine, because it gets deleted automatically!
+    $factoryVMName = "Factory VM"
+
+    # Amount of memory to give the VM - more memory usually makes updates install faster
+    $VMMemory = 1048mb
+
+    # Virtual switch to connect to - needs internet access to download updates
+    $virtualSwitchName = "Virtual Switch"
+
+    # Set to $true and specify VLAN id to connect the VM to a specific VLAN
+    $UseVLAN = $false
+    $VlanId = 1
 
 # Keys
 $Windows10Key = ""


### PR DESCRIPTION
I've added some additional error checking and warnings to make sure the working directory gets setup correctly:
- Moved the checkPath function to the top so it can be used right away, also hide it's output
- Check that workingDir exists, if not tell them to configure the script
- Create the folders under workingDir
- Check that Convert-WindowsImage exists, and gets loaded properly. Also tell them where to download and install it.
- Check that PSWindowsUpdate module exists, and tell them where to download and install it.
