### PR TITLE
Optimize final VHD

### DIFF
--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -340,13 +340,19 @@ function MountVHDandRunBlock
     param
     (
         [string]$vhd, 
-        [scriptblock]$block
+        [scriptblock]$block,
+        [switch]$ReadOnly
     );
      
     # This function mounts a VHD, runs a script block and unmounts the VHD.
     # Drive letter of the mounted VHD is stored in $driveLetter - can be used by script blocks
-    $driveLetter = (Mount-VHD $vhd -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter;
+    if($ReadOnly) {
+        $driveLetter = (Mount-VHD $vhd -ReadOnly -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter;
+    } else {
+        $driveLetter = (Mount-VHD $vhd -Passthru | Get-Disk | Get-Partition | Get-Volume).DriveLetter;
+    }
     & $block;
+
     Dismount-VHD $vhd;
 
     # Wait 2 seconds for activity to clean up
@@ -642,6 +648,14 @@ function RunTheFactory
         cleanupFile $finalVHD;
         logger $FriendlyName "Convert differencing disk into pristine base image";
         Convert-VHD -Path $sysprepVHD -DestinationPath $finalVHD -VHDType Dynamic;
+        logger $FriendlyName "Optimizing VHD file"
+        # Mounting the VHD read only allows it to be compacted better.
+        # Running Optimize-VHD twice seems to be necessary - don't know why, but it works.
+        MountVHDandRunBlock -ReadOnly $finalVHD {
+            Optimize-VHD $finalVHD -Mode Full
+            Optimize-VHD $finalVHD -Mode Full
+        }
+
         logger $FriendlyName "Delete differencing disk";
         CSVLogger $finalVHD -sysprepped;
         cleanupFile $sysprepVHD;

--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -640,6 +640,7 @@ function RunTheFactory
         # Remove Page file
         logger $FriendlyName "Removing the page file";
         MountVHDandRunBlock $sysprepVHD {
+
             attrib -s -h "$($driveLetter):\pagefile.sys";
             cleanupFile "$($driveLetter):\pagefile.sys";
         }
@@ -648,6 +649,14 @@ function RunTheFactory
         cleanupFile $finalVHD;
         logger $FriendlyName "Convert differencing disk into pristine base image";
         Convert-VHD -Path $sysprepVHD -DestinationPath $finalVHD -VHDType Dynamic;
+        if($CleanWinSXS) {
+            logger $FriendlyName "Cleaning windows component store. Be patient, this may take awhile."
+            MountVHDandRunBlock $finalVHD {
+                # Clean up the WinSXS store, and remove any superceded components. Updates will no longer be able to be uninstalled,
+                # but saves a considerable amount of disk space.
+                dism.exe /image:$($driveLetter):\ /Cleanup-Image /StartComponentCleanup /ResetBase
+            }
+        }
         logger $FriendlyName "Optimizing VHD file"
         # Mounting the VHD read only allows it to be compacted better.
         # Running Optimize-VHD twice seems to be necessary - don't know why, but it works.
@@ -655,7 +664,6 @@ function RunTheFactory
             Optimize-VHD $finalVHD -Mode Full
             Optimize-VHD $finalVHD -Mode Full
         }
-
         logger $FriendlyName "Delete differencing disk";
         CSVLogger $finalVHD -sysprepped;
         cleanupFile $sysprepVHD;

--- a/Image-Factory/FactoryVariables.ps1
+++ b/Image-Factory/FactoryVariables.ps1
@@ -38,3 +38,8 @@ $81x86Image = "$($workingDir)\ISOs\en_windows_8_1_x86_dvd_2707392.wim"
 $81x64Image = "$($workingDir)\ISOs\en_windows_8_1_x64_dvd_2707217.wim"
 $10x86Image = "$($workingDir)\ISOs\en_windows_10_multiple_editions_x86_dvd_6848465.wim"
 $10x64Image = "$($workingDir)\ISOs\en_windows_10_multiple_editions_x64_dvd_6846432.wim"
+
+# Misc Settings
+
+# If enabled, will use dism.exe to clean the WinSXS folder and remove old updates. This can give significant disk savings, but takes longer (20-30 minutes per image). Updates will not be able to be uninstalled if this is enabled.
+$CleanWinSXS = $false

--- a/Image-Factory/readme.md
+++ b/Image-Factory/readme.md
@@ -9,6 +9,11 @@ For more information - read here: http://blogs.msdn.com/b/virtual_pc_guy/archive
 
 # Change Log #
 
+8/17/15 -
+* Changes from Grant Emsley
+  * Optimize final VHD file
+  * Optionally clean the windows component store to save disk space
+
 8/16/15 -
 
 * Changes from Grant Emsley


### PR DESCRIPTION
This adds two methods of optimizing the final VHD to be smaller.

The first mounts the VHDX file read only, and runs "Optimize-VHD -Mode Full" on it twice. Mounting it read only allows it to do some more optimizing.  Why run it twice?  No idea, but at least on my Windows 8.1 test system, the first run does nothing, but the second one shrinks the images by about 100-200MB.

The second method is disabled by default and has to be turned on in FactoryVariables, because it takes an extra 20-30 minutes per image.  It uses dism to clean out the WinSXS directory of any superseded components.  This saves a further 100MB on my 2012R2 datacenter GUI image. I expect the amount saved will get even larger as time goes on and more updates get applied.

A few hundred MB in a 12-13GB image may not be much, but if you're deploying these files a lot it adds up quickly.
