### PR TITLE
Change out-host to .ToString() for codeblocks

### DIFF
--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -454,7 +454,7 @@ $updateCheckScriptBlock = {
 };
 
 function Set-UpdateCheckPlaceHolders {
-    $block = $updateCheckScriptBlock | Out-String
+    $block = $updateCheckScriptBlock.ToString()
     
     if($UseStaticIP) {
         $block = $block.Replace('$UseStaticIP = STATICIPBOOLPLACEHOLDER', '$UseStaticIP = $true')
@@ -679,7 +679,7 @@ function RunTheFactory
 
         logger $FriendlyName "Mount the differencing disk and copy in files";
         MountVHDandRunBlock $sysprepVHD {
-            $sysprepScriptBlockString = $sysprepScriptBlock | Out-String;
+            $sysprepScriptBlockString = $sysprepScriptBlock.ToString();
 
             if($GenericSysprep)
             {
@@ -707,7 +707,7 @@ function RunTheFactory
             if(-not $GenericSysprep)
             {
                 # Make the logon script
-                $postSysprepScriptBlock | Out-String | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
+                $postSysprepScriptBlock.ToString() | Out-File -FilePath "$($driveLetter):\Bits\Logon.ps1" -Width 4096;
             }
             else
             {

--- a/Image-Factory/readme.md
+++ b/Image-Factory/readme.md
@@ -9,6 +9,10 @@ For more information - read here: http://blogs.msdn.com/b/virtual_pc_guy/archive
 
 # Change Log #
 
+8/23715 -
+* Changes from Par Hultman
+  * Fixed problem with codeblocks that can result in un-wanted line breaks in script-files.
+
 8/21/15 -
 * Changes from Grant Emsley
   * Support configuration of static IP address on the factory VM


### PR DESCRIPTION
Hello, 
I would like to propose to change the way the code blocks gets converted to files, so instead of using out-string use the .tostring(). The reasons for this is that because out-string uses the column-width to decide where to put in extra line-breaks. So if you have a window with low width and high zoom the generated script-files in the vm can have some extra line-breaks that will break the process.

Regards Pär

Ps this is my first pull ever, hope I doing this “right”. Thanks for some great scripts.
