### PR TITLE
Added Win7 support, MD5 support, and more

### DIFF
--- a/Image-Factory/FactoryVariables.ps1
+++ b/Image-Factory/FactoryVariables.ps1
@@ -1,9 +1,10 @@
-# Seperate file for variables - this when you pull down the latest factory file you can keep your paths / product keys etc...
+# Separate file for variables - this when you pull down the latest factory file you can keep your paths / product keys etc...
+$acceptEULAs = $false
 $workingDir = "C:\FactoryTest"
 $logFile = "$($workingDir)\Share\Details.csv"
 $ResourceDirectory = "$($workingDir)\Resources" 
-$Organization = "The Power Elite"
-$Owner = "Ben Armstrong"
+$Organization = "Windows Image Factory"
+$Owner = "Windows Image Factory"
 $Timezone = "Pacific Standard Time"
 $adminPassword = "P@ssw0rd"
 $userPassword = "P@ssw0rd"
@@ -37,16 +38,25 @@ $Windows81Key = ""
 $Windows2012R2Key = ""
 $Windows8Key = ""
 $Windows2012Key = ""
+$Windows7Key = ""
+$windows7EntKey = ""
+$Windows2008R2Key = ""
 
 # ISOs /  WIMs
-$2012Image = "$($workingDir)\ISOs\en_windows_server_2012_x64_dvd_915478.wim"
-$2012R2Image = "$($workingDir)\ISOs\en_windows_server_2012_r2_x64_dvd_2707946.wim"
-$8x86Image = "$($workingDir)\ISOs\en_windows_8_x86_dvd_915417.wim"
-$8x64Image = "$($workingDir)\ISOs\en_windows_8_x64_dvd_915440.wim"
-$81x86Image = "$($workingDir)\ISOs\en_windows_8_1_x86_dvd_2707392.wim"
-$81x64Image = "$($workingDir)\ISOs\en_windows_8_1_x64_dvd_2707217.wim"
-$10x86Image = "$($workingDir)\ISOs\en_windows_10_multiple_editions_x86_dvd_6848465.wim"
-$10x64Image = "$($workingDir)\ISOs\en_windows_10_multiple_editions_x64_dvd_6846432.wim"
+# Note: Default ISO names taken from the MSDN Subscriber download naming convention
+$2012Image = "$($workingDir)\ISOs\en_windows_server_2012_x64_dvd_915478.iso"
+$2012R2Image = "$($workingDir)\ISOs\en_windows_server_2012_r2_x64_dvd_2707946.iso"
+$7x86Image = "$($workingDir)\ISOs\en_windows_7.iso"
+$7x64Image = "$($workingDir)\ISOs\en_windows_7_professional_with_sp1_x64_dvd_u_676939.iso"
+$7EntImage = "$($workingDir)\ISOs\en_windows_7_ent.iso"
+$7x86EntImage = "$($workingDir)\ISOs\en_windows_7_ent.iso"
+$2008R2Image = "$($workingDir)\ISOs\en_windows_2008_r2_x64.iso"
+$8x86Image = "$($workingDir)\ISOs\en_windows_8_x86_dvd_915417.iso"
+$8x64Image = "$($workingDir)\ISOs\en_windows_8_x64_dvd_915440.iso"
+$81x86Image = "$($workingDir)\ISOs\en_windows_8_1_x86_dvd_2707392.iso"
+$81x64Image = "$($workingDir)\ISOs\en_windows_8.1_with_update_x64_dvd_4065090.iso"
+$10x86Image = "$($workingDir)\ISOs\en_windows_10_multiple_editions_x86_dvd_6848465.iso"
+$10x64Image = "$($workingDir)\ISOs\en_windows_10_multiple_editions_x64_dvd_6846432.iso"
 
 # Misc Settings
 # If $startfactory is false, just import the functions to use in other scripts.  If true, start image generation.


### PR DESCRIPTION
- Updated checks for PS-WindowsUpdate and Convert-WindowsImage to
  automatically download the latest versions of each
- Added check to Factory.ps1 to verify that end user has accepted the
  EULAs for third-party components
- Removed Unblock-File check for PS-WindowsUpdate as Invoke-WebRequest
  does not add the Zone Identifier for files downloaded from the internet
- Added support for Windows 7 and Windows Server 2008 R2
- MD5 hashes are now generated for resultant VHDX files
