### PR TITLE
Checking internet connection with Invoke-WebRequest instead of Test-Connection

### DIFF
--- a/Image-Factory/Factory.ps1
+++ b/Image-Factory/Factory.ps1
@@ -501,7 +501,7 @@ $updateCheckScriptBlock = {
     {
         Start-Sleep -Seconds 5;
 		logger "Checking for Internet connection"
-    } until (Test-Connection -computername www.microsoft.com)
+    } until ((Invoke-WebRequest http://www.microsoft.com).StatusCode -eq 200)
 	
     # Run pre-update script if it exists
     if (Test-Path "$env:SystemDrive\Bits\PreUpdateScript.ps1") {


### PR DESCRIPTION
Changed the internet connection check to use ((Invoke-WebRequest http://www.microsoft.com).StatusCode -eq 200) as Test-Connection is not allowed on some networks (the one I was using), so the test would fail.
